### PR TITLE
Fix error when no query and db overlap

### DIFF
--- a/man/BIGprofiler.Rd
+++ b/man/BIGprofiler.Rd
@@ -48,7 +48,7 @@ clusterProfiler of significant genes in Broad gene sets
 }
 \examples{
 #Get gene names for enrichment
-gene_list <- list(HRV1 = names(example.gene.list[[1]]),
+gene_list <- list(HRV1 = "notReal",
                   HRV2 = names(example.gene.list[[2]]))
 BIGprofiler(gene_list, ID="ENSEMBL", category="H")
 
@@ -60,7 +60,7 @@ BIGprofiler(gene_df=gene_df, ID="ENSEMBL", category="H")
 
 #Use custom data base
 db <- data.frame(module = c(rep("module1",10), rep("module2",10)),
-                 symbol = sample(gene_list[[1]], 20))
+                 symbol = sample(gene_list[[2]], 20))
 
 BIGprofiler(gene_list, ID="ENSEMBL", db=db)
 }

--- a/man/BIGsea.Rd
+++ b/man/BIGsea.Rd
@@ -43,10 +43,10 @@ BIGsea(example.gene.list, category="H", ID="ENSEMBL")
 BIGsea(example.gene.list, category="C2", subcategory="CP", ID="ENSEMBL")
 
 #Use gene_df
-gene_df <- data.frame(gs_name = c(rep("HRV1", 100), rep("HRV2",100)),
-                      gene = c(names(example.gene.list[[1]]),
+gene_df <- data.frame(gs_name = c("HRV1", rep("HRV2",100)),
+                      gene = c("notReal",
                                names(example.gene.list[[2]])),
-                     logFC = c(example.gene.list[[1]],
+                     logFC = c(example.gene.list[[1]][1],
                                example.gene.list[[2]]))
 BIGsea(gene_df=gene_df, category="H", ID="ENSEMBL")
 


### PR DESCRIPTION
**Describe the purpose of these changes**
Return result with message "No overlap of query genes and specified database." instead of erroring out. Continue with other query sets as normal. Impacts `BIGprofiler`, `BIGsea`, `flexEnrich`

**Tests**


R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
