### PR TITLE
Refactor msigdbr function calls for consistency in parameter naming. …

### DIFF
--- a/R/BIGprofiler.R
+++ b/R/BIGprofiler.R
@@ -67,7 +67,7 @@ BIGprofiler <- function(gene_list = NULL, gene_df = NULL, ID = "SYMBOL",
       species <- "Mus musculus"
       db_species <- "MM"
     }
-    db.format <- msigdbr::msigdbr(species, db_species, collection=collection)
+    db.format <- msigdbr::msigdbr(species = species, db_species = db_species, collection = collection)
     #Subset subcollection if selected
     if(!is.null(subcollection)){
       #Check that subcollection exists in msigdb

--- a/R/BIGsea.R
+++ b/R/BIGsea.R
@@ -97,7 +97,7 @@ BIGsea <- function(gene_list = NULL, gene_df = NULL,
       species <- "Mus musculus"
       db_species <- "MM"
     }
-    db.format <- msigdbr::msigdbr(species, db_species, collection=collection)
+    db.format <- msigdbr::msigdbr(species = species, db_species = db_species, collection = collection)
     #Subset subcollection if selected
     if(!is.null(subcollection)){
       #Check that subcollection exists in msigdb

--- a/R/flexEnrich.R
+++ b/R/flexEnrich.R
@@ -66,7 +66,7 @@ flexEnrich <- function(gene_list = NULL,
       species <- "Mus musculus"
       db_species <- "MM"
     }
-    db.format <- msigdbr::msigdbr(species, db_species, collection=collection)
+    db.format <- msigdbr::msigdbr(species = species, db_species = db_species, collection = collection)
     # remove gene sets that are too small or too large
     good_pw <- db.format %>%
       dplyr::group_by(gs_name) %>%

--- a/R/iterEnrich.R
+++ b/R/iterEnrich.R
@@ -111,7 +111,7 @@ iterEnrich <- function(anno_df = NULL,
       species <- "Mus musculus"
       db_species <- "MM"
     }
-    db.format <- msigdbr::msigdbr(species, db_species, collection=collection)
+    db.format <- msigdbr::msigdbr(species = species, db_species = db_species, collection = collection)
     #Subset subcollection if selected
     if(!is.null(subcollection)){
       #Check that subcollection exists in msigdb


### PR DESCRIPTION
The order of parameters changed from msigdb, causing the function to fail

**Describe the purpose of these changes**
msigdbr changed their order of parameters from msigdbr::msigdbr(**species**, **db_species**, collection=collection)
to msigdbr::msigdbr(**db_species**, **species**,  collection=collection)

So changed the code to explicitly call out the parameters


