### PR TITLE
add some flexibility to "species" parameter

### DIFF
--- a/R/BIGprofiler.R
+++ b/R/BIGprofiler.R
@@ -53,11 +53,11 @@ BIGprofiler <- function(gene_list = NULL, gene_df = NULL, ID = "SYMBOL",
   #Load gene ontology
   if(!is.null(collection)){
     #Recode species
-    if(species == "human"){
+    if(species %in% c("human", "Homo sapiens", "HS")){
       species <- "Homo sapiens"
       db_species <- "HS"
     }
-    if(species == "mouse"){
+    if(species %in% c("mouse", "Mus musculus", "MM")){
       species <- "Mus musculus"
       db_species <- "MM"
     }

--- a/R/flexEnrich.R
+++ b/R/flexEnrich.R
@@ -48,11 +48,11 @@ flexEnrich <- function(gene_list = NULL,
   if(!is.null(category)){stop("category is deprecated. Please use collection.")}
 
   #Recode species
-  if(species == "human"){
+  if(species %in% c("human", "Homo sapiens", "HS")){
     species <- "Homo sapiens"
     db_species <- "HS"
   }
-  if(species == "mouse"){
+  if(species %in% c("mouse", "Mus musculus", "MM")){
     species <- "Mus musculus"
     db_species <- "MM"
   }

--- a/R/iterEnrich.R
+++ b/R/iterEnrich.R
@@ -97,11 +97,11 @@ iterEnrich <- function(anno_df = NULL,
   if(!is.null(collection)){
     #Recode species
     species_og <- species
-    if(species == "human"){
+    if(species %in% c("human", "Homo sapiens", "HS")){
       species <- "Homo sapiens"
       db_species <- "HS"
     }
-    if(species == "mouse"){
+    if(species %in% c("mouse", "Mus musculus", "MM")){
       species <- "Mus musculus"
       db_species <- "MM"
     }

--- a/man/BIGprofiler.Rd
+++ b/man/BIGprofiler.Rd
@@ -13,7 +13,7 @@ BIGprofiler(
   subcollection = NULL,
   db = NULL,
   minGSSize = 10,
-  maxGSSize = 500,
+  maxGSSize = 1e+10,
   category = NULL,
   subcategory = NULL
 )
@@ -39,7 +39,7 @@ gene_symbol, entrez_gene, or ensembl_gene as matches your gene_list names)}
 size). Default \code{10}. See \code{\link[clusterProfiler:enricher]{clusterProfiler::enricher()}}}
 
 \item{maxGSSize}{Numeric. Maximum size of genes annotated for testing (maximum pathway
-size). Default \code{500}. See \code{\link[clusterProfiler:enricher]{clusterProfiler::enricher()}}}
+size). Default \code{1e10}. See \code{\link[clusterProfiler:enricher]{clusterProfiler::enricher()}}}
 
 \item{category}{Deprecated}
 


### PR DESCRIPTION
make informal name ("human", "mouse"), latin name ("Homo sapiens", "Mus musculus"), or two-letter indicator ("HS", "MM") all translate for the species parameter

**Describe the purpose of these changes**
A clear and concise description of what the bug or feature request this pull request addresses. Link to a current GitHub issue if available.

**Tests**
Verify that you have completed the following tests by checking the appropriate box. All tests must pass prior to merging with the main branch.

R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [ ] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
